### PR TITLE
fix: header and footer links

### DIFF
--- a/404.html
+++ b/404.html
@@ -35,14 +35,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -83,10 +83,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -95,11 +95,8 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-                <li>
-                  <a href="downloads/series-and-servers.html">Map
-                    downloads</a>
-                </li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+                <li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
               </ul>
             </div>
           </div>
@@ -109,9 +106,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -119,12 +116,13 @@
             <div class="widget">
               <h5 class="widgetheading">Other</h5>
               <ul class="link-list">
-                <li>
-                  <a href="https://github.com/UFO-Studios/TheAlienDoctor.com">Contribute,
-                    report bugs and more on GitHub</a>
-                </li>
-                <li>
-                  <a href="https://github.com/UFO-Studios" target="_blank">Developed by UFO Studios</a>
+                <li><a href="https://github.com/UFO-Studios/TheAlienDoctor.com">Contribute,
+                    report bugs
+                    and
+                    more on GitHub</a></li>
+                <li><a href="https://github.com/UFO-Studios" target="_blank">Developed
+                    by UFO
+                    Studios</a>
                 </li>
               </ul>
             </div>
@@ -137,13 +135,10 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
-                    &#169; UFO Studios &#38; TheAlienDoctor
-                  </a>
-                  |
-                  <a href="http://webthemez.com" target="_blank">Template By
-                    WebThemez</a>
-                  | Site Version: V1.8.4
+                  <a href="/legal/licence.html" target="_blank">
+                    &#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
+                    target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
+
                 </p>
               </div>
             </div>

--- a/about.html
+++ b/about.html
@@ -37,14 +37,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
+							<li><a href="/index.html">Home</a></li>
 							<li class="active"><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -130,10 +130,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -142,7 +142,7 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="/UFO-SMP/apply.html">Apply to join</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
 								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
@@ -153,9 +153,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -182,7 +182,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/downloads/alien-totems.html
+++ b/downloads/alien-totems.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Alien Totems resource pack</h2>
           </div>
@@ -171,10 +171,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -183,9 +183,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -197,9 +197,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -225,7 +225,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/alienbot.html
+++ b/downloads/alienbot.html
@@ -41,14 +41,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark Mode [Beta]</a></li>
 						</ul>
 					</div>
@@ -220,10 +220,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -232,8 +232,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -243,9 +243,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -270,7 +270,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 								</p>

--- a/downloads/aliens-ui-pack.html
+++ b/downloads/aliens-ui-pack.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Alien's UI resource pack</h2>
           </div>
@@ -483,10 +483,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -495,9 +495,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -509,9 +509,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -537,7 +537,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/anti-enderman-griefing.html
+++ b/downloads/anti-enderman-griefing.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -150,10 +150,10 @@
           <div class="widget">
             <h5 class="widgetheading">Quick Links</h5>
             <ul class="link-list">
-              <li><a href="r/YouTube.html">YouTube</a></li>
-              <li><a href="r/Discord.html">Discord server</a></li>
-              <li><a href="r/Twitter.html">Twitter</a></li>
-              <li><a href="r/Patreon.html">Patreon</a></li>
+              <li><a href="/r/YouTube.html">YouTube</a></li>
+              <li><a href="/r/Discord.html">Discord server</a></li>
+              <li><a href="/r/Twitter.html">Twitter</a></li>
+              <li><a href="/r/Patreon.html">Patreon</a></li>
             </ul>
           </div>
         </div>
@@ -162,9 +162,9 @@
             <h5 class="widgetheading">UFO SMP</h5>
             <ul class="link-list">
               <li><a href="/ufo-smp">Info</a></li>
-              <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+              <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
               <li>
-                <a href="downloads/series-and-servers.html">Map
+                <a href="/downloads/series-and-servers.html">Map
                   downloads</a>
               </li>
             </ul>
@@ -176,9 +176,9 @@
               <p>Legal</p>
             </h5>
             <ul class="link-list">
-              <li><a href="legal/privacy.html">Privacy</a></li>
-              <li><a href="legal/licence.html">Licence</a></li>
-              <li><a href="legal/eula.html">Site eula</a></li>
+              <li><a href="/legal/privacy.html">Privacy</a></li>
+              <li><a href="/legal/licence.html">Licence</a></li>
+              <li><a href="/legal/eula.html">Site eula</a></li>
             </ul>
           </div>
         </div>
@@ -204,7 +204,7 @@
           <div class="col-lg-6">
             <div class="copyright">
               <p>
-                <a href="legal/licence.html" target="_blank">
+                <a href="/legal/licence.html" target="_blank">
                   &#169; UFO Studios &#38; TheAlienDoctor
                 </a>
                 |

--- a/downloads/anti-zombie-griefing.html
+++ b/downloads/anti-zombie-griefing.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -149,10 +149,10 @@
           <div class="widget">
             <h5 class="widgetheading">Quick Links</h5>
             <ul class="link-list">
-              <li><a href="r/YouTube.html">YouTube</a></li>
-              <li><a href="r/Discord.html">Discord server</a></li>
-              <li><a href="r/Twitter.html">Twitter</a></li>
-              <li><a href="r/Patreon.html">Patreon</a></li>
+              <li><a href="/r/YouTube.html">YouTube</a></li>
+              <li><a href="/r/Discord.html">Discord server</a></li>
+              <li><a href="/r/Twitter.html">Twitter</a></li>
+              <li><a href="/r/Patreon.html">Patreon</a></li>
             </ul>
           </div>
         </div>
@@ -161,9 +161,9 @@
             <h5 class="widgetheading">UFO SMP</h5>
             <ul class="link-list">
               <li><a href="/ufo-smp">Info</a></li>
-              <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+              <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
               <li>
-                <a href="downloads/series-and-servers.html">Map
+                <a href="/downloads/series-and-servers.html">Map
                   downloads</a>
               </li>
             </ul>
@@ -175,9 +175,9 @@
               <p>Legal</p>
             </h5>
             <ul class="link-list">
-              <li><a href="legal/privacy.html">Privacy</a></li>
-              <li><a href="legal/licence.html">Licence</a></li>
-              <li><a href="legal/eula.html">Site eula</a></li>
+              <li><a href="/legal/privacy.html">Privacy</a></li>
+              <li><a href="/legal/licence.html">Licence</a></li>
+              <li><a href="/legal/eula.html">Site eula</a></li>
             </ul>
           </div>
         </div>
@@ -203,7 +203,7 @@
           <div class="col-lg-6">
             <div class="copyright">
               <p>
-                <a href="legal/licence.html" target="_blank">
+                <a href="/legal/licence.html" target="_blank">
                   &#169; UFO Studios &#38; TheAlienDoctor
                 </a>
                 |

--- a/downloads/apps-software.html
+++ b/downloads/apps-software.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -190,10 +190,10 @@
           <div class="widget">
             <h5 class="widgetheading">Quick Links</h5>
             <ul class="link-list">
-              <li><a href="r/YouTube.html">YouTube</a></li>
-              <li><a href="r/Discord.html">Discord server</a></li>
-              <li><a href="r/Twitter.html">Twitter</a></li>
-              <li><a href="r/Patreon.html">Patreon</a></li>
+              <li><a href="/r/YouTube.html">YouTube</a></li>
+              <li><a href="/r/Discord.html">Discord server</a></li>
+              <li><a href="/r/Twitter.html">Twitter</a></li>
+              <li><a href="/r/Patreon.html">Patreon</a></li>
             </ul>
           </div>
         </div>
@@ -202,9 +202,9 @@
             <h5 class="widgetheading">UFO SMP</h5>
             <ul class="link-list">
               <li><a href="/ufo-smp">Info</a></li>
-              <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+              <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
               <li>
-                <a href="downloads/series-and-servers.html">Map
+                <a href="/downloads/series-and-servers.html">Map
                   downloads</a>
               </li>
             </ul>
@@ -216,9 +216,9 @@
               <p>Legal</p>
             </h5>
             <ul class="link-list">
-              <li><a href="legal/privacy.html">Privacy</a></li>
-              <li><a href="legal/licence.html">Licence</a></li>
-              <li><a href="legal/eula.html">Site eula</a></li>
+              <li><a href="/legal/privacy.html">Privacy</a></li>
+              <li><a href="/legal/licence.html">Licence</a></li>
+              <li><a href="/legal/eula.html">Site eula</a></li>
             </ul>
           </div>
         </div>
@@ -244,7 +244,7 @@
           <div class="col-lg-6">
             <div class="copyright">
               <p>
-                <a href="legal/licence.html" target="_blank">
+                <a href="/legal/licence.html" target="_blank">
                   &#169; UFO Studios &#38; TheAlienDoctor
                 </a>
                 |

--- a/downloads/armour-trim-hider.html
+++ b/downloads/armour-trim-hider.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Alien Armour Trim Hider resource pack</h2>
           </div>
@@ -160,10 +160,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -172,9 +172,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -186,9 +186,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -214,7 +214,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/bds-companion.html
+++ b/downloads/bds-companion.html
@@ -39,14 +39,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark Mode [Beta]</a>
               </li>
@@ -217,10 +217,10 @@
           <div class="widget">
             <h5 class="widgetheading">Quick Links</h5>
             <ul class="link-list">
-              <li><a href="r/YouTube.html">YouTube</a></li>
-              <li><a href="r/Discord.html">Discord server</a></li>
-              <li><a href="r/Twitter.html">Twitter</a></li>
-              <li><a href="r/Patreon.html">Patreon</a></li>
+              <li><a href="/r/YouTube.html">YouTube</a></li>
+              <li><a href="/r/Discord.html">Discord server</a></li>
+              <li><a href="/r/Twitter.html">Twitter</a></li>
+              <li><a href="/r/Patreon.html">Patreon</a></li>
             </ul>
           </div>
         </div>
@@ -229,9 +229,9 @@
             <h5 class="widgetheading">UFO SMP</h5>
             <ul class="link-list">
               <li><a href="/ufo-smp">Info</a></li>
-              <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+              <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
               <li>
-                <a href="downloads/series-and-servers.html">Map downloads</a>
+                <a href="/downloads/series-and-servers.html">Map downloads</a>
               </li>
             </ul>
           </div>
@@ -242,9 +242,9 @@
               <p>Legal</p>
             </h5>
             <ul class="link-list">
-              <li><a href="legal/privacy.html">Privacy</a></li>
-              <li><a href="legal/licence.html">Licence</a></li>
-              <li><a href="legal/eula.html">Site eula</a></li>
+              <li><a href="/legal/privacy.html">Privacy</a></li>
+              <li><a href="/legal/licence.html">Licence</a></li>
+              <li><a href="/legal/eula.html">Site eula</a></li>
             </ul>
           </div>
         </div>
@@ -270,7 +270,7 @@
           <div class="col-lg-6">
             <div class="copyright">
               <p>
-                <a href="legal/licence.html" target="_blank">
+                <a href="/legal/licence.html" target="_blank">
                   &#169; UFO Studios &#38; TheAlienDoctor
                 </a>
                 |

--- a/downloads/behaviour-packs.html
+++ b/downloads/behaviour-packs.html
@@ -39,14 +39,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -246,10 +246,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -258,8 +258,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -269,9 +269,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -298,7 +298,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 								</p>

--- a/downloads/better-netherite.html
+++ b/downloads/better-netherite.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Better Netherite</h2>
           </div>
@@ -208,10 +208,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -220,9 +220,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -234,9 +234,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -262,7 +262,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/clearchat.html
+++ b/downloads/clearchat.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Clearchat resource pack</h2>
           </div>
@@ -207,10 +207,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -219,9 +219,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -233,9 +233,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -261,7 +261,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/craftable-chainmail-armour.html
+++ b/downloads/craftable-chainmail-armour.html
@@ -41,14 +41,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -166,10 +166,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -178,9 +178,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -192,9 +192,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -220,7 +220,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/craftable-rooted-dirt.html
+++ b/downloads/craftable-rooted-dirt.html
@@ -40,14 +40,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -177,10 +177,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -189,9 +189,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -203,9 +203,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -231,7 +231,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/custom-fog.html
+++ b/downloads/custom-fog.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Custom Fog resource pack</h2>
           </div>
@@ -182,10 +182,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -194,9 +194,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -208,9 +208,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -236,7 +236,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/download-recorder.html
+++ b/downloads/download-recorder.html
@@ -39,14 +39,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -213,10 +213,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -225,8 +225,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -236,9 +236,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -265,7 +265,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 								</p>

--- a/downloads/eddp.html
+++ b/downloads/eddp.html
@@ -39,14 +39,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark Mode [Beta]</a></li>
 						</ul>
 					</div>
@@ -210,10 +210,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -222,8 +222,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -233,9 +233,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -260,7 +260,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 								</p>

--- a/downloads/greenscreen.html
+++ b/downloads/greenscreen.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Greenscreen pack</h2>
           </div>
@@ -170,10 +170,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -182,9 +182,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -196,9 +196,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -224,7 +224,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/hardcore-pack.html
+++ b/downloads/hardcore-pack.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -179,10 +179,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -191,9 +191,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -205,9 +205,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -233,7 +233,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/helmet-hider.html
+++ b/downloads/helmet-hider.html
@@ -38,15 +38,15 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
 
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -60,7 +60,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Helmet Hider resource pack</h2>
           </div>
@@ -225,10 +225,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -237,9 +237,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -251,9 +251,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -279,7 +279,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/index.html
+++ b/downloads/index.html
@@ -41,14 +41,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
 							<li class="active"><a href="downloads/index.html">Downloads</a></li>
 							<li><a href="fan-art.html">fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -124,7 +124,7 @@
 				</div>
 				<div class="row">
 					<div class="col-md-4">
-						<a href="downloads/series-and-servers.html" style="text-decoration: none;">
+						<a href="/downloads/series-and-servers.html" style="text-decoration: none;">
 							<div class="downloadbox">
 								<center>
 									<img src="img/downloads-headers/series-servers.png">
@@ -176,10 +176,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -188,8 +188,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -199,9 +199,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -228,7 +228,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/downloads/nicer-rain.html
+++ b/downloads/nicer-rain.html
@@ -38,15 +38,15 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
 
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -60,7 +60,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Nicer Rain resource pack</h2>
           </div>
@@ -164,10 +164,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -176,9 +176,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -190,9 +190,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -218,7 +218,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/no-end.html
+++ b/downloads/no-end.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -178,10 +178,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -190,9 +190,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -204,9 +204,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -232,7 +232,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/no-nether.html
+++ b/downloads/no-nether.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -172,10 +172,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -184,9 +184,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -198,9 +198,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -226,7 +226,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/one-player-sleep.html
+++ b/downloads/one-player-sleep.html
@@ -39,14 +39,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -373,10 +373,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -385,9 +385,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -399,9 +399,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -427,7 +427,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/other.html
+++ b/downloads/other.html
@@ -39,14 +39,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -129,10 +129,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -141,9 +141,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -155,9 +155,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -183,7 +183,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/pack-converter.html
+++ b/downloads/pack-converter.html
@@ -40,14 +40,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -416,10 +416,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -428,9 +428,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -442,9 +442,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -470,7 +470,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/pano-selector.html
+++ b/downloads/pano-selector.html
@@ -48,14 +48,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark Mode [Beta]</a></li>
 							</li>
 						</ul>
@@ -288,10 +288,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -300,8 +300,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -311,9 +311,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -338,7 +338,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/downloads/piglin-to-pigman.html
+++ b/downloads/piglin-to-pigman.html
@@ -39,14 +39,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -60,7 +60,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Piglin to Pigman</h2>
           </div>
@@ -196,10 +196,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -208,9 +208,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -222,9 +222,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -250,7 +250,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/potion-bubble-hider.html
+++ b/downloads/potion-bubble-hider.html
@@ -40,14 +40,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -61,7 +61,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Potion Bubble hider resource Pack</h2>
           </div>
@@ -215,10 +215,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -227,9 +227,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -241,9 +241,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -269,7 +269,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/potion-hud-hider.html
+++ b/downloads/potion-hud-hider.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Potion HUD Hider resource pack</h2>
           </div>
@@ -192,10 +192,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -204,9 +204,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -218,9 +218,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -246,7 +246,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/red-beacons.html
+++ b/downloads/red-beacons.html
@@ -37,14 +37,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
             </ul>
           </div>
         </div>
@@ -54,7 +54,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Alien Red Beacons resource pack</h2>
           </div>
@@ -148,10 +148,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -160,9 +160,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -174,9 +174,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -202,7 +202,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/resource-packs.html
+++ b/downloads/resource-packs.html
@@ -41,14 +41,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -428,10 +428,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -440,8 +440,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -451,9 +451,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -480,7 +480,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 								</p>

--- a/downloads/series-and-servers.html
+++ b/downloads/series-and-servers.html
@@ -43,15 +43,15 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
 
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -187,10 +187,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -199,8 +199,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map
 										downloads</a></li>
 							</ul>
 						</div>
@@ -211,9 +211,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -239,7 +239,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/downloads/setting-space-fixer.html
+++ b/downloads/setting-space-fixer.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -59,7 +59,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Setting Space Fixer resource pack</h2>
           </div>
@@ -161,10 +161,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -173,9 +173,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -187,9 +187,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -215,7 +215,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/skinpack.html
+++ b/downloads/skinpack.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -243,10 +243,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -255,9 +255,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -269,9 +269,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -297,7 +297,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/toggleable-coordinates-and-days.html
+++ b/downloads/toggleable-coordinates-and-days.html
@@ -40,14 +40,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -227,10 +227,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -239,8 +239,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map
 										downloads</a></li>
 							</ul>
 						</div>
@@ -251,9 +251,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -279,7 +279,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/downloads/tutorial-worlds.html
+++ b/downloads/tutorial-worlds.html
@@ -43,14 +43,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -143,7 +143,7 @@
 							might be because not
 							every tutorial I have made also has a world download. If your really
 							really sure that
-							something is missing, then either join <a href="r/Discord.html">my
+							something is missing, then either join <a href="/r/Discord.html">my
 								Discord</a> and let me
 							know via the help channel, or open an issue on GitHub if you know what
 							your doing</p>
@@ -158,10 +158,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -170,8 +170,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -181,9 +181,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -210,7 +210,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/downloads/updated-1.8-textures.html
+++ b/downloads/updated-1.8-textures.html
@@ -40,14 +40,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -61,7 +61,7 @@
     <section id="inner-headline">
       <div class="container">
         <div class="row">
-          <a href="downloads/resource-packs.html" class="btn-blue"> Back</a>
+          <a href="/downloads/resource-packs.html" class="btn-blue"> Back</a>
           <div class="col-lg-12">
             <h2 class="pageTitle">Updated 1.8 Textures</h2>
           </div>
@@ -271,10 +271,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -283,9 +283,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -297,9 +297,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -325,7 +325,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/wallpaper-pack.html
+++ b/downloads/wallpaper-pack.html
@@ -38,14 +38,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -118,10 +118,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -130,9 +130,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -144,9 +144,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -172,7 +172,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/downloads/xmas-chests.html
+++ b/downloads/xmas-chests.html
@@ -39,14 +39,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -186,10 +186,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -198,8 +198,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -209,9 +209,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -238,7 +238,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/fan-art.html
+++ b/fan-art.html
@@ -39,16 +39,16 @@
                     </div>
                     <div class="navbar-collapse collapse">
                         <ul class="nav navbar-nav">
-                            <li><a href="index.html">Home</a></li>
-                            <li><a href="about.html">About</a></li>
-                            <li><a href="downloads/index.html">Downloads</a></li>
+                            <li><a href="/index.html">Home</a></li>
+                            <li><a href="/about.html">About</a></li>
+                            <li><a href="/downloads/index.html">Downloads</a></li>
                             <li class="active"><a href="fan-art.html">Fan
                                     Art</a></li>
-                            <li><a href="ufo-smp">UFO SMP</a></li>
+                            <li><a href="/ufo-smp">UFO SMP</a></li>
                             <li><a href="ufo-studios.html">UFO
                                     Studios</a></li>
-                            <li><a href="links.html">Links</a></li>
-                            <li><a href="my-setup.html">My Setup</a></li>
+                            <li><a href="/links.html">Links</a></li>
+                            <li><a href="/my-setup.html">My Setup</a></li>
                             <li>
                                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                                     Dark Mode [Beta]</a>
@@ -363,11 +363,10 @@
                         <div class="widget">
                             <h5 class="widgetheading">Quick Links</h5>
                             <ul class="link-list">
-                                <li><a href="r/YouTube.html">YouTube</a></li>
-                                <li><a href="r/Discord.html">Discord
-                                        server</a></li>
-                                <li><a href="r/Twitter.html">Twitter</a></li>
-                                <li><a href="r/Patreon.html">Patreon</a></li>
+                                <li><a href="/r/YouTube.html">YouTube</a></li>
+                                <li><a href="/r/Discord.html">Discord server</a></li>
+                                <li><a href="/r/Twitter.html">Twitter</a></li>
+                                <li><a href="/r/Patreon.html">Patreon</a></li>
                             </ul>
                         </div>
                     </div>
@@ -376,12 +375,8 @@
                             <h5 class="widgetheading">UFO SMP</h5>
                             <ul class="link-list">
                                 <li><a href="/ufo-smp">Info</a></li>
-                                <li><a href="UFO-SMP/apply.html">Apply to
-                                        join</a></li>
-                                <li>
-                                    <a href="downloads/series-and-servers.html">Map
-                                        downloads</a>
-                                </li>
+                                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+                                <li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
                             </ul>
                         </div>
                     </div>
@@ -391,10 +386,9 @@
                                 <p>Legal</p>
                             </h5>
                             <ul class="link-list">
-                                <li><a href="legal/privacy.html">Privacy</a></li>
-                                <li><a href="legal/licence.html">Licence</a></li>
-                                <li><a href="legal/eula.html">Site
-                                        eula</a></li>
+                                <li><a href="/legal/privacy.html">Privacy</a></li>
+                                <li><a href="/legal/licence.html">Licence</a></li>
+                                <li><a href="/legal/eula.html">Site eula</a></li>
                             </ul>
                         </div>
                     </div>
@@ -421,7 +415,7 @@
                         <div class="col-lg-6">
                             <div class="copyright">
                                 <p>
-                                    <a href="legal/licence.html" target="_blank">
+                                    <a href="/legal/licence.html" target="_blank">
                                         &#169; UFO Studios &#38;
                                         TheAlienDoctor
                                     </a>

--- a/index.html
+++ b/index.html
@@ -42,13 +42,13 @@
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
 							<li class="active"><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark Mode [Beta]</a></li>
 							</li>
 						</ul>
@@ -306,7 +306,7 @@
 			<br>
 			<div class="row">
 				<div class="col-md-4">
-					<a href="r/YouTube.html" style="text-decoration: none;">
+					<a href="/r/YouTube.html" style="text-decoration: none;">
 						<center>
 							<img src="img/social-badges/youtube.png">
 						</center>
@@ -320,7 +320,7 @@
 					</a>
 				</div>
 				<div class="col-md-4">
-					<a href="r/Twitter.html" style="text-decoration: none;">
+					<a href="/r/Twitter.html" style="text-decoration: none;">
 						<center>
 							<img src="img/social-badges/twitter.png">
 						</center>
@@ -329,7 +329,7 @@
 			</div>
 			<div class="row">
 				<div class="col-md-4">
-					<a href="r/Patreon.html" style="text-decoration: none;">
+					<a href="/r/Patreon.html" style="text-decoration: none;">
 						<center>
 							<img src="img/social-badges/patreon.png">
 						</center>
@@ -360,10 +360,10 @@
 					<div class="widget">
 						<h5 class="widgetheading">Quick Links</h5>
 						<ul class="link-list">
-							<li><a href="r/YouTube.html">YouTube</a></li>
-							<li><a href="r/Discord.html">Discord server</a></li>
-							<li><a href="r/Twitter.html">Twitter</a></li>
-							<li><a href="r/Patreon.html">Patreon</a></li>
+							<li><a href="/r/YouTube.html">YouTube</a></li>
+							<li><a href="/r/Discord.html">Discord server</a></li>
+							<li><a href="/r/Twitter.html">Twitter</a></li>
+							<li><a href="/r/Patreon.html">Patreon</a></li>
 						</ul>
 					</div>
 				</div>
@@ -372,8 +372,8 @@
 						<h5 class="widgetheading">UFO SMP</h5>
 						<ul class="link-list">
 							<li><a href="/ufo-smp">Info</a></li>
-							<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-							<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+							<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+							<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 						</ul>
 					</div>
 				</div>
@@ -383,9 +383,9 @@
 							<p>Legal</p>
 						</h5>
 						<ul class="link-list">
-							<li><a href="legal/privacy.html">Privacy</a></li>
-							<li><a href="legal/licence.html">Licence</a></li>
-							<li><a href="legal/eula.html">Site eula</a></li>
+							<li><a href="/legal/privacy.html">Privacy</a></li>
+							<li><a href="/legal/licence.html">Licence</a></li>
+							<li><a href="/legal/eula.html">Site eula</a></li>
 						</ul>
 					</div>
 				</div>
@@ -393,9 +393,13 @@
 					<div class="widget">
 						<h5 class="widgetheading">Other</h5>
 						<ul class="link-list">
-							<li><a href="https://github.com/UFO-Studios/TheAlienDoctor.com">Contribute, report bugs and
+							<li><a href="https://github.com/UFO-Studios/TheAlienDoctor.com">Contribute,
+									report bugs
+									and
 									more on GitHub</a></li>
-							<li><a href="https://github.com/UFO-Studios" target="_blank">Developed by UFO Studios</a>
+							<li><a href="https://github.com/UFO-Studios" target="_blank">Developed
+									by UFO
+									Studios</a>
 							</li>
 						</ul>
 					</div>
@@ -408,9 +412,10 @@
 					<div class="col-lg-6">
 						<div class="copyright">
 							<p>
-								<a href="legal/licence.html" target="_blank">
+								<a href="/legal/licence.html" target="_blank">
 									&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 									target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
+
 							</p>
 						</div>
 					</div>

--- a/legal/eula.html
+++ b/legal/eula.html
@@ -40,14 +40,14 @@
                     </div>
                     <div class="navbar-collapse collapse ">
                         <ul class="nav navbar-nav">
-                            <li><a href="index.html">Home</a></li>
-                            <li><a href="about.html">About</a></li>
-                            <li><a href="downloads/index.html">Downloads</a></li>
-                            <li><a href="fan-art.html">Fan Art</a></li>
-                            <li><a href="ufo-smp">UFO SMP</a></li>
-                            <li><a href="ufo-studios.html">UFO Studios</a></li>
-                            <li><a href="links.html">Links</a></li>
-                            <li><a href="my-setup.html">My Setup</a></li>
+                            <li><a href="/index.html">Home</a></li>
+                            <li><a href="/about.html">About</a></li>
+                            <li><a href="/downloads/index.html">Downloads</a></li>
+                            <li><a href="/fan-art.html">Fan Art</a></li>
+                            <li><a href="/ufo-smp">UFO SMP</a></li>
+                            <li><a href="/ufo-studios.html">UFO Studios</a></li>
+                            <li><a href="/links.html">Links</a></li>
+                            <li><a href="/my-setup.html">My Setup</a></li>
                         </ul>
                     </div>
                 </div>
@@ -120,7 +120,7 @@
                                     class="app_name">TheAlienDoctor.com</span> software.</p>
 
                             <p>This website falls under the BSD-3 Clause License. Please read the <a
-                                    href="legal/licence.html">license page</a> to view the license for this websites
+                                    href="/legal/licence.html">license page</a> to view the license for this websites
                                 source code.</p>
 
                             <h3>Intellectual Property and Ownership</h3>
@@ -165,10 +165,10 @@
                         <div class="widget">
                             <h5 class="widgetheading">Quick Links</h5>
                             <ul class="link-list">
-                                <li><a href="r/YouTube.html">YouTube</a></li>
-                                <li><a href="r/Discord.html">Discord server</a></li>
-                                <li><a href="r/Twitter.html">Twitter</a></li>
-                                <li><a href="r/Patreon.html">Patreon</a></li>
+                                <li><a href="/r/YouTube.html">YouTube</a></li>
+                                <li><a href="/r/Discord.html">Discord server</a></li>
+                                <li><a href="/r/Twitter.html">Twitter</a></li>
+                                <li><a href="/r/Patreon.html">Patreon</a></li>
                             </ul>
                         </div>
                     </div>
@@ -177,8 +177,8 @@
                             <h5 class="widgetheading">UFO SMP</h5>
                             <ul class="link-list">
                                 <li><a href="/ufo-smp">Info</a></li>
-                                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-                                <li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+                                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+                                <li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
                             </ul>
                         </div>
                     </div>
@@ -188,9 +188,9 @@
                                 <p>Legal</p>
                             </h5>
                             <ul class="link-list">
-                                <li><a href="legal/privacy.html">Privacy</a></li>
-                                <li><a href="legal/licence.html">Licence</a></li>
-                                <li><a href="legal/eula.html">Site eula</a></li>
+                                <li><a href="/legal/privacy.html">Privacy</a></li>
+                                <li><a href="/legal/licence.html">Licence</a></li>
+                                <li><a href="/legal/eula.html">Site eula</a></li>
                             </ul>
                         </div>
                     </div>
@@ -215,7 +215,7 @@
                         <div class="col-lg-6">
                             <div class="copyright">
                                 <p>
-                                    <a href="legal/licence.html" target="_blank">
+                                    <a href="/legal/licence.html" target="_blank">
                                         &#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
                                         target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
                                 </p>

--- a/legal/licence.html
+++ b/legal/licence.html
@@ -37,15 +37,15 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
 
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -116,10 +116,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -128,9 +128,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -142,9 +142,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -170,7 +170,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/legal/privacy.html
+++ b/legal/privacy.html
@@ -40,14 +40,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark Mode [Beta]</a></li>
 						</ul>
 					</div>
@@ -104,10 +104,10 @@
 					<div class="widget">
 						<h5 class="widgetheading">Quick Links</h5>
 						<ul class="link-list">
-							<li><a href="r/YouTube.html">YouTube</a></li>
-							<li><a href="r/Discord.html">Discord server</a></li>
-							<li><a href="r/Twitter.html">Twitter</a></li>
-							<li><a href="r/Patreon.html">Patreon</a></li>
+							<li><a href="/r/YouTube.html">YouTube</a></li>
+							<li><a href="/r/Discord.html">Discord server</a></li>
+							<li><a href="/r/Twitter.html">Twitter</a></li>
+							<li><a href="/r/Patreon.html">Patreon</a></li>
 						</ul>
 					</div>
 				</div>
@@ -116,8 +116,8 @@
 						<h5 class="widgetheading">UFO SMP</h5>
 						<ul class="link-list">
 							<li><a href="/ufo-smp">Info</a></li>
-							<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-							<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+							<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+							<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 						</ul>
 					</div>
 				</div>
@@ -127,9 +127,9 @@
 							<p>Legal</p>
 						</h5>
 						<ul class="link-list">
-							<li><a href="legal/privacy.html">Privacy</a></li>
-							<li><a href="legal/licence.html">Licence</a></li>
-							<li><a href="legal/eula.html">Site eula</a></li>
+							<li><a href="/legal/privacy.html">Privacy</a></li>
+							<li><a href="/legal/licence.html">Licence</a></li>
+							<li><a href="/legal/eula.html">Site eula</a></li>
 						</ul>
 					</div>
 				</div>
@@ -154,7 +154,7 @@
 					<div class="col-lg-6">
 						<div class="copyright">
 							<p>
-								<a href="legal/licence.html" target="_blank">
+								<a href="/legal/licence.html" target="_blank">
 									&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 									target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 							</p>

--- a/links.html
+++ b/links.html
@@ -39,14 +39,14 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
 							<li class="active"><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 
@@ -87,7 +87,7 @@
 				</div>
 				<div class="row">
 					<div class="col-md-4">
-						<a href="r/YouTube.html" style="text-decoration: none;">
+						<a href="/r/YouTube.html" style="text-decoration: none;">
 							<center>
 								<img src="img/social-badges/youtube.png">
 							</center>
@@ -101,7 +101,7 @@
 						</a>
 					</div>
 					<div class="col-md-4">
-						<a href="r/Discord.html" style="text-decoration: none;">
+						<a href="/r/Discord.html" style="text-decoration: none;">
 							<center>
 								<img src="img/social-badges/discord.png">
 							</center>
@@ -110,14 +110,14 @@
 				</div>
 				<div class="row">
 					<div class="col-md-4">
-						<a href="r/Twitter.html" style="text-decoration: none;">
+						<a href="/r/Twitter.html" style="text-decoration: none;">
 							<center>
 								<img src="img/social-badges/twitter.png">
 							</center>
 						</a>
 					</div>
 					<div class="col-md-4">
-						<a href="r/Patreon.html" style="text-decoration: none;">
+						<a href="/r/Patreon.html" style="text-decoration: none;">
 							<center>
 								<img src="img/social-badges/patreon.png">
 							</center>
@@ -164,10 +164,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -176,8 +176,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -187,9 +187,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -216,7 +216,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/my-setup.html
+++ b/my-setup.html
@@ -40,13 +40,13 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
-							<li><a href="ufo-studios.html">UFO Studios</a></li>
-							<li><a href="links.html">Links</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
+							<li><a href="/ufo-studios.html">UFO Studios</a></li>
+							<li><a href="/links.html">Links</a></li>
 							<li class="active"><a href="my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
@@ -511,10 +511,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -523,8 +523,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -534,9 +534,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -563,7 +563,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 

--- a/ufo-smp/index.html
+++ b/ufo-smp/index.html
@@ -43,16 +43,16 @@
                     </div>
                     <div class="navbar-collapse collapse ">
                         <ul class="nav navbar-nav">
-                            <li><a href="index.html">Home</a></li>
-                            <li><a href="about.html">About</a></li>
-                            <li><a href="downloads/index.html">Downloads</a></li>
-                            <li><a href="fan-art.html">Fan Art</a></li>
+                            <li><a href="/index.html">Home</a></li>
+                            <li><a href="/about.html">About</a></li>
+                            <li><a href="/downloads/index.html">Downloads</a></li>
+                            <li><a href="/fan-art.html">Fan Art</a></li>
                             <li class="active"><a href="ufo-smp/">UFO
                                     SMP</a></li>
                             <li><a href="ufo-studios.html">UFO
                                     Studios</a></li>
-                            <li><a href="links.html">Links</a></li>
-                            <li><a href="my-setup.html">My Setup</a></li>
+                            <li><a href="/links.html">Links</a></li>
+                            <li><a href="/my-setup.html">My Setup</a></li>
                             <li><a href="#" onclick="toggleDarkMode(); return false;">Toggle
                                     Dark Mode [Beta]</a></li>
                         </ul>
@@ -111,7 +111,7 @@
                                 style="height:13px;display:block;"></span>
                             <P>To join you must meet the following requirements:</P>
                             <li>To join you must be over the age of 13</li>
-                            <li>Need to be level 5+ in my <a href="r/Discord.html">Discord</a> (you gain levels from
+                            <li>Need to be level 5+ in my <a href="/r/Discord.html">Discord</a> (you gain levels from
                                 chatting) or a Patron/YouTube Member at any level.</li>
                             <li>You will then gain access to the apply channel, where you can open an application and
                                 answer a few short questions.</li>
@@ -183,7 +183,7 @@
                                 server?</b> You can find a list of the
                             plugins
                             used
-                            <a href="UFO-SMP/plugins.html">here</a>, most of
+                            <a href="/ufo-smp/plugins.html">here</a>, most of
                             them are for admin purposes.
                         </p>
                         <p><b>Is it cross play, and if so which versions
@@ -195,7 +195,7 @@
                             Redstone and farm designs will need to work on
                             Java edition for it to work on UFO SMP
                         </p>
-                        <p>Anymore questions? Ask them on <a href="r/Discord.html">my Discord
+                        <p>Anymore questions? Ask them on <a href="/r/Discord.html">my Discord
                                 server!</a></p>
                     </div>
                 </section>
@@ -209,11 +209,11 @@
                         <div class="widget">
                             <h5 class="widgetheading">Quick Links</h5>
                             <ul class="link-list">
-                                <li><a href="r/YouTube.html">YouTube</a></li>
-                                <li><a href="r/Discord.html">Discord
+                                <li><a href="/r/YouTube.html">YouTube</a></li>
+                                <li><a href="/r/Discord.html">Discord
                                         server</a></li>
-                                <li><a href="r/Twitter.html">Twitter</a></li>
-                                <li><a href="r/Patreon.html">Patreon</a></li>
+                                <li><a href="/r/Twitter.html">Twitter</a></li>
+                                <li><a href="/r/Patreon.html">Patreon</a></li>
                             </ul>
                         </div>
                     </div>
@@ -222,9 +222,9 @@
                             <h5 class="widgetheading">UFO SMP</h5>
                             <ul class="link-list">
                                 <li><a href="/ufo-smp">Info</a></li>
-                                <li><a href="UFO-SMP/apply.html">Apply to
+                                <li><a href="/ufo-smp/apply.html">Apply to
                                         join</a></li>
-                                <li><a href="downloads/series-and-servers.html">Map
+                                <li><a href="/downloads/series-and-servers.html">Map
                                         downloads</a></li>
                             </ul>
                         </div>
@@ -235,9 +235,9 @@
                                 <p>Legal</p>
                             </h5>
                             <ul class="link-list">
-                                <li><a href="legal/privacy.html">Privacy</a></li>
-                                <li><a href="legal/licence.html">Licence</a></li>
-                                <li><a href="legal/eula.html">Site
+                                <li><a href="/legal/privacy.html">Privacy</a></li>
+                                <li><a href="/legal/licence.html">Licence</a></li>
+                                <li><a href="/legal/eula.html">Site
                                         eula</a></li>
                             </ul>
                         </div>
@@ -264,7 +264,7 @@
                         <div class="col-lg-6">
                             <div class="copyright">
                                 <p>
-                                    <a href="legal/licence.html" target="_blank">
+                                    <a href="/legal/licence.html" target="_blank">
                                         &#169; UFO Studios &#38;
                                         TheAlienDoctor </a> | <a href="http://webthemez.com" target="_blank">Template By
                                         WebThemez</a> | Site Version: V1.8.4

--- a/ufo-smp/s0.html
+++ b/ufo-smp/s0.html
@@ -40,14 +40,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp/">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -91,7 +91,7 @@
         </div>
       </div>
       <br />
-      <a href="downloads/series-and-servers.html" class="btn-blue">
+      <a href="/downloads/series-and-servers.html" class="btn-blue">
         World download</a>
     </center>
     <section id="content">
@@ -173,10 +173,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -185,9 +185,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -199,9 +199,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -227,7 +227,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/ufo-smp/s1.html
+++ b/ufo-smp/s1.html
@@ -40,14 +40,14 @@
           </div>
           <div class="navbar-collapse collapse">
             <ul class="nav navbar-nav">
-              <li><a href="index.html">Home</a></li>
-              <li><a href="about.html">About</a></li>
-              <li><a href="downloads/index.html">Downloads</a></li>
-              <li><a href="fan-art.html">Fan Art</a></li>
-              <li><a href="ufo-smp/">UFO SMP</a></li>
-              <li><a href="ufo-studios.html">UFO Studios</a></li>
-              <li><a href="links.html">Links</a></li>
-              <li><a href="my-setup.html">My Setup</a></li>
+              <li><a href="/index.html">Home</a></li>
+              <li><a href="/about.html">About</a></li>
+              <li><a href="/downloads/index.html">Downloads</a></li>
+              <li><a href="/fan-art.html">Fan Art</a></li>
+              <li><a href="/ufo-smp">UFO SMP</a></li>
+              <li><a href="/ufo-studios.html">UFO Studios</a></li>
+              <li><a href="/links.html">Links</a></li>
+              <li><a href="/my-setup.html">My Setup</a></li>
               <li>
                 <a href="#" onclick="toggleDarkMode(); return false;">Toggle
                   Dark Mode [Beta]</a>
@@ -90,7 +90,7 @@
         </div>
       </div>
       <br />
-      <a href="downloads/series-and-servers.html" class="btn-blue">
+      <a href="/downloads/series-and-servers.html" class="btn-blue">
         World download</a>
     </center>
     <section id="content">
@@ -183,10 +183,10 @@
             <div class="widget">
               <h5 class="widgetheading">Quick Links</h5>
               <ul class="link-list">
-                <li><a href="r/YouTube.html">YouTube</a></li>
-                <li><a href="r/Discord.html">Discord server</a></li>
-                <li><a href="r/Twitter.html">Twitter</a></li>
-                <li><a href="r/Patreon.html">Patreon</a></li>
+                <li><a href="/r/YouTube.html">YouTube</a></li>
+                <li><a href="/r/Discord.html">Discord server</a></li>
+                <li><a href="/r/Twitter.html">Twitter</a></li>
+                <li><a href="/r/Patreon.html">Patreon</a></li>
               </ul>
             </div>
           </div>
@@ -195,9 +195,9 @@
               <h5 class="widgetheading">UFO SMP</h5>
               <ul class="link-list">
                 <li><a href="/ufo-smp">Info</a></li>
-                <li><a href="UFO-SMP/apply.html">Apply to join</a></li>
+                <li><a href="/ufo-smp/apply.html">Apply to join</a></li>
                 <li>
-                  <a href="downloads/series-and-servers.html">Map
+                  <a href="/downloads/series-and-servers.html">Map
                     downloads</a>
                 </li>
               </ul>
@@ -209,9 +209,9 @@
                 <p>Legal</p>
               </h5>
               <ul class="link-list">
-                <li><a href="legal/privacy.html">Privacy</a></li>
-                <li><a href="legal/licence.html">Licence</a></li>
-                <li><a href="legal/eula.html">Site eula</a></li>
+                <li><a href="/legal/privacy.html">Privacy</a></li>
+                <li><a href="/legal/licence.html">Licence</a></li>
+                <li><a href="/legal/eula.html">Site eula</a></li>
               </ul>
             </div>
           </div>
@@ -237,7 +237,7 @@
             <div class="col-lg-6">
               <div class="copyright">
                 <p>
-                  <a href="legal/licence.html" target="_blank">
+                  <a href="/legal/licence.html" target="_blank">
                     &#169; UFO Studios &#38; TheAlienDoctor
                   </a>
                   |

--- a/ufo-smp/s2.html
+++ b/ufo-smp/s2.html
@@ -43,15 +43,15 @@
                     </div>
                     <div class="navbar-collapse collapse ">
                         <ul class="nav navbar-nav">
-                            <li><a href="index.html">Home</a></li>
-                            <li><a href="about.html">About</a></li>
-                            <li><a href="downloads/index.html">Downloads</a></li>
-                            <li><a href="fan-art.html">Fan Art</a></li>
-                            <li><a href="ufo-smp/">UFO SMP</a></li>
+                            <li><a href="/index.html">Home</a></li>
+                            <li><a href="/about.html">About</a></li>
+                            <li><a href="/downloads/index.html">Downloads</a></li>
+                            <li><a href="/fan-art.html">Fan Art</a></li>
+                            <li><a href="/ufo-smp">UFO SMP</a></li>
                             <li><a href="ufo-studios.html">UFO
                                     Studios</a></li>
-                            <li><a href="links.html">Links</a></li>
-                            <li><a href="my-setup.html">My Setup</a></li>
+                            <li><a href="/links.html">Links</a></li>
+                            <li><a href="/my-setup.html">My Setup</a></li>
                             <li><a href="#" onclick="toggleDarkMode(); return false;">Toggle
                                     Dark Mode [Beta]</a></li>
                         </ul>
@@ -93,7 +93,7 @@
             </div>
             <br>
             <br />
-            <a href="downloads/series-and-servers.html" class="btn-blue">
+            <a href="/downloads/series-and-servers.html" class="btn-blue">
                 World download</a>
         </center>
         <section id="content">
@@ -191,11 +191,11 @@
                         <div class="widget">
                             <h5 class="widgetheading">Quick Links</h5>
                             <ul class="link-list">
-                                <li><a href="r/YouTube.html">YouTube</a></li>
-                                <li><a href="r/Discord.html">Discord
+                                <li><a href="/r/YouTube.html">YouTube</a></li>
+                                <li><a href="/r/Discord.html">Discord
                                         server</a></li>
-                                <li><a href="r/Twitter.html">Twitter</a></li>
-                                <li><a href="r/Patreon.html">Patreon</a></li>
+                                <li><a href="/r/Twitter.html">Twitter</a></li>
+                                <li><a href="/r/Patreon.html">Patreon</a></li>
                             </ul>
                         </div>
                     </div>
@@ -204,9 +204,9 @@
                             <h5 class="widgetheading">UFO SMP</h5>
                             <ul class="link-list">
                                 <li><a href="/ufo-smp">Info</a></li>
-                                <li><a href="UFO-SMP/apply.html">Apply to
+                                <li><a href="/ufo-smp/apply.html">Apply to
                                         join</a></li>
-                                <li><a href="downloads/series-and-servers.html">Map
+                                <li><a href="/downloads/series-and-servers.html">Map
                                         downloads</a></li>
                             </ul>
                         </div>
@@ -217,9 +217,9 @@
                                 <p>Legal</p>
                             </h5>
                             <ul class="link-list">
-                                <li><a href="legal/privacy.html">Privacy</a></li>
-                                <li><a href="legal/licence.html">Licence</a></li>
-                                <li><a href="legal/eula.html">Site
+                                <li><a href="/legal/privacy.html">Privacy</a></li>
+                                <li><a href="/legal/licence.html">Licence</a></li>
+                                <li><a href="/legal/eula.html">Site
                                         eula</a></li>
                             </ul>
                         </div>
@@ -246,7 +246,7 @@
                         <div class="col-lg-6">
                             <div class="copyright">
                                 <p>
-                                    <a href="legal/licence.html" target="_blank">
+                                    <a href="/legal/licence.html" target="_blank">
                                         &#169; UFO Studios &#38;
                                         TheAlienDoctor </a> | <a href="http://webthemez.com" target="_blank">Template By
                                         WebThemez</a> | Site Version: V1.8.4

--- a/ufo-smp/s3.html
+++ b/ufo-smp/s3.html
@@ -43,15 +43,15 @@
                     </div>
                     <div class="navbar-collapse collapse ">
                         <ul class="nav navbar-nav">
-                            <li><a href="index.html">Home</a></li>
-                            <li><a href="about.html">About</a></li>
-                            <li><a href="downloads/index.html">Downloads</a></li>
-                            <li><a href="fan-art.html">Fan Art</a></li>
-                            <li><a href="ufo-smp/">UFO SMP</a></li>
+                            <li><a href="/index.html">Home</a></li>
+                            <li><a href="/about.html">About</a></li>
+                            <li><a href="/downloads/index.html">Downloads</a></li>
+                            <li><a href="/fan-art.html">Fan Art</a></li>
+                            <li><a href="/ufo-smp">UFO SMP</a></li>
                             <li><a href="ufo-studios.html">UFO
                                     Studios</a></li>
-                            <li><a href="links.html">Links</a></li>
-                            <li><a href="my-setup.html">My Setup</a></li>
+                            <li><a href="/links.html">Links</a></li>
+                            <li><a href="/my-setup.html">My Setup</a></li>
                             <li><a href="#" onclick="toggleDarkMode(); return false;">Toggle
                                     Dark Mode [Beta]</a></li>
                         </ul>
@@ -148,11 +148,11 @@
                         <div class="widget">
                             <h5 class="widgetheading">Quick Links</h5>
                             <ul class="link-list">
-                                <li><a href="r/YouTube.html">YouTube</a></li>
-                                <li><a href="r/Discord.html">Discord
+                                <li><a href="/r/YouTube.html">YouTube</a></li>
+                                <li><a href="/r/Discord.html">Discord
                                         server</a></li>
-                                <li><a href="r/Twitter.html">Twitter</a></li>
-                                <li><a href="r/Patreon.html">Patreon</a></li>
+                                <li><a href="/r/Twitter.html">Twitter</a></li>
+                                <li><a href="/r/Patreon.html">Patreon</a></li>
                             </ul>
                         </div>
                     </div>
@@ -161,9 +161,9 @@
                             <h5 class="widgetheading">UFO SMP</h5>
                             <ul class="link-list">
                                 <li><a href="/ufo-smp">Info</a></li>
-                                <li><a href="UFO-SMP/apply.html">Apply to
+                                <li><a href="/ufo-smp/apply.html">Apply to
                                         join</a></li>
-                                <li><a href="downloads/series-and-servers.html">Map
+                                <li><a href="/downloads/series-and-servers.html">Map
                                         downloads</a></li>
                             </ul>
                         </div>
@@ -174,9 +174,9 @@
                                 <p>Legal</p>
                             </h5>
                             <ul class="link-list">
-                                <li><a href="legal/privacy.html">Privacy</a></li>
-                                <li><a href="legal/licence.html">Licence</a></li>
-                                <li><a href="legal/eula.html">Site
+                                <li><a href="/legal/privacy.html">Privacy</a></li>
+                                <li><a href="/legal/licence.html">Licence</a></li>
+                                <li><a href="/legal/eula.html">Site
                                         eula</a></li>
                             </ul>
                         </div>
@@ -203,7 +203,7 @@
                         <div class="col-lg-6">
                             <div class="copyright">
                                 <p>
-                                    <a href="legal/licence.html" target="_blank">
+                                    <a href="/legal/licence.html" target="_blank">
                                         &#169; UFO Studios &#38;
                                         TheAlienDoctor </a> | <a href="http://webthemez.com" target="_blank">Template By
                                         WebThemez</a> | Site Version: V1.8.4

--- a/ufo-studios.html
+++ b/ufo-studios.html
@@ -40,15 +40,15 @@
 					</div>
 					<div class="navbar-collapse collapse ">
 						<ul class="nav navbar-nav">
-							<li><a href="index.html">Home</a></li>
-							<li><a href="about.html">About</a></li>
-							<li><a href="downloads/index.html">Downloads</a></li>
-							<li><a href="fan-art.html">Fan Art</a></li>
-							<li><a href="ufo-smp">UFO SMP</a></li>
+							<li><a href="/index.html">Home</a></li>
+							<li><a href="/about.html">About</a></li>
+							<li><a href="/downloads/index.html">Downloads</a></li>
+							<li><a href="/fan-art.html">Fan Art</a></li>
+							<li><a href="/ufo-smp">UFO SMP</a></li>
 							<li class="active"><a href="ufo-studios.html">UFO Studios</a></li>
 
-							<li><a href="links.html">Links</a></li>
-							<li><a href="my-setup.html">My Setup</a></li>
+							<li><a href="/links.html">Links</a></li>
+							<li><a href="/my-setup.html">My Setup</a></li>
 							<li><a href="#" onclick="toggleDarkMode(); return false;">Toggle Dark
 									Mode [Beta]</a></li>
 						</ul>
@@ -134,10 +134,10 @@
 						<div class="widget">
 							<h5 class="widgetheading">Quick Links</h5>
 							<ul class="link-list">
-								<li><a href="r/YouTube.html">YouTube</a></li>
-								<li><a href="r/Discord.html">Discord server</a></li>
-								<li><a href="r/Twitter.html">Twitter</a></li>
-								<li><a href="r/Patreon.html">Patreon</a></li>
+								<li><a href="/r/YouTube.html">YouTube</a></li>
+								<li><a href="/r/Discord.html">Discord server</a></li>
+								<li><a href="/r/Twitter.html">Twitter</a></li>
+								<li><a href="/r/Patreon.html">Patreon</a></li>
 							</ul>
 						</div>
 					</div>
@@ -146,8 +146,8 @@
 							<h5 class="widgetheading">UFO SMP</h5>
 							<ul class="link-list">
 								<li><a href="/ufo-smp">Info</a></li>
-								<li><a href="UFO-SMP/apply.html">Apply to join</a></li>
-								<li><a href="downloads/series-and-servers.html">Map downloads</a></li>
+								<li><a href="/ufo-smp/apply.html">Apply to join</a></li>
+								<li><a href="/downloads/series-and-servers.html">Map downloads</a></li>
 							</ul>
 						</div>
 					</div>
@@ -157,9 +157,9 @@
 								<p>Legal</p>
 							</h5>
 							<ul class="link-list">
-								<li><a href="legal/privacy.html">Privacy</a></li>
-								<li><a href="legal/licence.html">Licence</a></li>
-								<li><a href="legal/eula.html">Site eula</a></li>
+								<li><a href="/legal/privacy.html">Privacy</a></li>
+								<li><a href="/legal/licence.html">Licence</a></li>
+								<li><a href="/legal/eula.html">Site eula</a></li>
 							</ul>
 						</div>
 					</div>
@@ -186,7 +186,7 @@
 						<div class="col-lg-6">
 							<div class="copyright">
 								<p>
-									<a href="legal/licence.html" target="_blank">
+									<a href="/legal/licence.html" target="_blank">
 										&#169; UFO Studios &#38; TheAlienDoctor </a> | <a href="http://webthemez.com"
 										target="_blank">Template By WebThemez</a> | Site Version: V1.8.4
 


### PR DESCRIPTION
This PR fixes some broken links in the header and footer via VS Code's mass replace.

## Relative to Absolute Links

```html
<ul class="link-list">
    <li><a href="legal/privacy.html">Privacy</a></li>
    <li><a href="legal/licence.html">Licence</a></li>
    <li><a href="legal/eula.html">Site eula</a></li>
</ul>
```

These relative links were causing problems if you navigate to, say, `thealiendoctor.com/legal/privacy`.

Using a relative link there would lead to `thealiendoctor.com/legal/legal/privacy`, resulting in an error page, as the current directory would be interpreted as `/legal` instead of `/`.

This PR changes links like those to absolute ones:

```html
<ul class="link-list">
    <li><a href="/legal/privacy.html">Privacy</a></li>
    <li><a href="/legal/licence.html">Licence</a></li>
    <li><a href="/legal/eula.html">Site eula</a></li>
</ul>
```

## Broken Links

The links `UFO-SMP/apply.html` and `UFO-SMP/plugins.html` are broken completely, this PR changes them to use lowercase `ufo-smp`.

## Links Affected

- `UFO-SMP/apply.html` -> `/ufo-smp/apply.html`
- `index.html` -> `/index.html`
- `about.html` -> `/about.html`
- `downloads/index.html` -> `/downloads/index.html`
- `fan-art.html` -> `/fan-art.html`
- `ufo-smp` -> `/ufo-smp`
- `ufo-studios.html` -> `/ufo-studios.html`
- `links.html` -> `/links.html`
- `my-setup.html` -> `/my-setup.html`

- `r/YouTube.html` -> `/r/YouTube.html`
- `r/Discord.html` -> `/r/Discord.html`
- `r/Twitter.html` -> `/r/Twitter.html`
- `r/Patreon.html` -> `/r/Patreon.html`
- `downloads/series-and-servers.html` -> `/downloads/series-and-servers.html`

- `legal/privacy.html` -> `/legal/privacy.html`
- `legal/licence.html` -> `/legal/licence.html`
- `legal/eula.html` -> `/legal/eula.html`

- `UFO-SMP/plugins.html` -> `/ufo-smp/plugins.html`